### PR TITLE
yarn buildがlintエラーで失敗するため、lintエラー解消

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "start": "next start",
     "codegen": "graphql-codegen --config codegen.yml",
     "test": "jest",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:web": "eslint components/**/*.{ts,tsx} features/**/*.ts pages/**/*.tsx"
   },
   "dependencies": {
     "@apollo/client": "^3.7.7",


### PR DESCRIPTION
# 背景
https://github.com/tumeda1992/nanitabe/issues/1
でyarn buildしようと思ったら、lintエラーでビルドできなかった。

# やること
この機会に以下をやっておく

- must
    - buildできるくらいにlint修正する
- better
    - この機会にlintをアップデートする
        - おびただしいlintエラーが起きている `✖ 298 problems (271 errors, 27 warnings)`
        - そもそもエラーとすべきか、いつもの編集時に自動修正させるか考える